### PR TITLE
Feat/exclude file setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ const jsoMetroPlugin = require("obfuscator-io-metro-plugin")(
   {
     runInDev: false /* optional */,
     logObfuscatedFiles: true /* optional generated files will be located at ./.jso */,
+    excludes: '**/*.assets.**' /* optional, A file names or globs which indicates files to exclude from obfuscation. */, 
   }
 );
 

--- a/lib/javascriptObfuscatorAPI.js
+++ b/lib/javascriptObfuscatorAPI.js
@@ -18,6 +18,17 @@ module.exports = async function({ config, filesSrc, filesDest, cwd, runConfig })
     })
   }));
 
+  const excludeFiles = await (new Promise((resolve, reject) => {
+    if (!runConfig?.excludes) return resolve([]);
+    glob(runConfig.excludes, { cwd }, function (er, files) {
+      if (er) {
+        reject(er);
+      } else {
+        resolve(files);
+      }
+    })
+  }));
+
   const postData = {};
   postData.Items = await Promise.all(files.map(async (f) => {
     return {
@@ -31,6 +42,9 @@ module.exports = async function({ config, filesSrc, filesDest, cwd, runConfig })
 
   postData.Items.map((item)=>
   {
+    if (excludeFiles.indexOf(item.FileName) >= 0) {
+      return;
+    }
     sourceMaps = sourceMaps.addFile({source:`${item.FileCode}`,sourceFile:item.FileName},offset);
     try{
       const obfuscationResult = JavaScriptObfuscator.obfuscate(`${item.FileCode}`, config);


### PR DESCRIPTION
Added an "exclude" option for JavaScript obfuscation.

**README.md:** Updated documentation to include the new `excludes` option.
**lib/javascriptObfuscatorAPI.js:** Integrated logic to allow specific files or patterns to be excluded from obfuscation based on `runConfig.excludes`. Files matching the specified glob patterns will be omitted, enhancing customization and control over obfuscation.

This improvement is useful for cases where certain assets should remain unobfuscated, facilitating easier debugging or performance optimizations in specific modules.