### PR TITLE
fix #32 issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ buck-out/
 *.obfuscated.mock.js
 ios/assets/
 /bundle.*
+integration-rn-0841-newarch/

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+integration-rn-0841-newarch/
+.jso/
+test/

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,7 +22,7 @@ const debug = !!process.env.DEBUG;
 
 async function obfuscateBundle(
   {bundlePath, bundleSourceMapPath},
-  fileNames,
+  files,
   config,
   runConfig
 ) {
@@ -38,32 +38,38 @@ async function obfuscateBundle(
 
   // build tmp src folders structure
   await Promise.all(
-    fileNames.map(n =>
-      mkdirp(`${SRC_TEMP_FOLDER}/${path.dirname(n)}`)
+    files.map(({fileName}) =>
+      mkdirp(`${SRC_TEMP_FOLDER}/${path.dirname(fileName)}`)
     )
   );
 
   // write user files to tmp folder
   await Promise.all(
     metroUserFilesOnly.map((c, i) =>
-      writeFile(`${SRC_TEMP_FOLDER}/${fileNames[i]}`, c)
+      writeFile(`${SRC_TEMP_FOLDER}/${files[i].fileName}`, c)
     )
   )
 
   const filesSrc = `**/*.js?(.map)`;
   const filesDest = DIST_TEMP_FOLDER;
   const cwd = SRC_TEMP_FOLDER;
+  const fileConfigs = files.reduce((acc, file) => {
+    acc[file.fileName] = {
+      reservedNames: file.reservedNames
+    };
+    return acc;
+  }, {});
 
   if (bundleSourceMapPath) {
     console.warn(`Metro is generating source maps that won't be useful after obfuscation.`);
   }
 
   // Loop through filesSrc and obfuscate files and save to filesDest.
-  await obfuscate({ config, filesSrc, filesDest, cwd, runConfig });
+  await obfuscate({ config, filesSrc, filesDest, cwd, runConfig, fileConfigs });
 
   // read obfuscated user files
   const obfusctedUserFiles = await Promise.all(metroUserFilesOnly.map((c, i) =>
-    readFile(`${DIST_TEMP_FOLDER}/${fileNames[i]}`, 'utf8')
+    readFile(`${DIST_TEMP_FOLDER}/${files[i].fileName}`, 'utf8')
   ));
 
   // build final bundle (with JSO TAGS still)
@@ -100,13 +106,14 @@ module.exports = function (_config = {}, runConfig = {}, projectRoot = process.c
 
   const config = _config;
   const bundlePath = getBundlePath();
-  const fileNames = new Set();
+  const files = [];
+  const fileNameCounts = {};
 
   process.on('beforeExit', async function (exitCode) {
     try{
       console.log('info: Obfuscating Code');
       // start obfuscation
-      await obfuscateBundle(bundlePath, Array.from(fileNames), config, runConfig);
+      await obfuscateBundle(bundlePath, files, config, runConfig);
       if(!runConfig || !runConfig.logObfuscatedFiles){
         await remove(TEMP_FOLDER); // clear temp folder 
       }
@@ -128,8 +135,8 @@ module.exports = function (_config = {}, runConfig = {}, projectRoot = process.c
        */
       processModuleFilter(_module) {
         if (
-          _module.path.indexOf('node_modules') !== -1 ||
           typeof _module.path !== 'string' ||
+          _module.path.indexOf('node_modules') !== -1 ||
           !fs.existsSync(_module.path) ||
           !path.extname(_module.path).match(EXTS)
         ) {
@@ -137,12 +144,34 @@ module.exports = function (_config = {}, runConfig = {}, projectRoot = process.c
         }
 
         const normalizePath = buildNormalizePath(_module.path, projectRoot);
-        fileNames.add(normalizePath);
-        _module.output.forEach(({data}) => {
-          wrapCodeWithTags(data);
+        _module.output.forEach(({data}, outputIndex) => {
+          if (!data || typeof data.code !== 'string') {
+            return;
+          }
+          const fileName = buildUniqueFileName(
+            fileNameCounts,
+            normalizePath ||
+              `__virtual__/module-${files.length}-output-${outputIndex}.js`
+          );
+          const { reservedNames } = wrapCodeWithTags(data);
+          files.push({ fileName, reservedNames });
         });
         return true;
       }
     }
   };
 };
+
+function buildUniqueFileName(fileNameCounts, fileName) {
+  const count = fileNameCounts[fileName] || 0;
+  fileNameCounts[fileName] = count + 1;
+
+  if (count === 0) {
+    return fileName;
+  }
+
+  const ext = path.extname(fileName);
+  const dir = path.dirname(fileName);
+  const basename = path.basename(fileName, ext);
+  return path.join(dir, `${basename}-${count}${ext || '.js'}`);
+}

--- a/lib/javascriptObfuscatorAPI.js
+++ b/lib/javascriptObfuscatorAPI.js
@@ -6,7 +6,7 @@ var convert = require('convert-source-map');
 var combine = require('combine-source-map');
 var generatedSourceMapLocation = "index.android.bundle.map";
 
-module.exports = async function({ config, filesSrc, filesDest, cwd, runConfig }) {
+module.exports = async function({ config, filesSrc, filesDest, cwd, runConfig, fileConfigs = {} }) {
   console.log({ config, filesSrc, filesDest, cwd });
   const files = await (new Promise((resolve, reject) => {
     glob(filesSrc, { cwd }, function (er, files) {
@@ -33,7 +33,8 @@ module.exports = async function({ config, filesSrc, filesDest, cwd, runConfig })
   {
     sourceMaps = sourceMaps.addFile({source:`${item.FileCode}`,sourceFile:item.FileName},offset);
     try{
-      const obfuscationResult = JavaScriptObfuscator.obfuscate(`${item.FileCode}`, config);
+      const safeConfig = buildSafeConfig(config, fileConfigs[item.FileName]);
+      const obfuscationResult = JavaScriptObfuscator.obfuscate(`${item.FileCode}`, safeConfig);
       item.FileCode= obfuscationResult.getObfuscatedCode();
       // item.SourceMap = obfuscationResult.getSourceMap();
     }
@@ -57,3 +58,37 @@ module.exports = async function({ config, filesSrc, filesDest, cwd, runConfig })
     console.log(`generated source map file located at ${generatedSourceMapLocation}`);
   }
 };
+
+function buildSafeConfig(config = {}, fileConfig = {}) {
+  config = config || {};
+  fileConfig = fileConfig || {};
+  const reservedNames = [
+    ...toArray(config.reservedNames),
+    ...toExactNamePatterns(fileConfig.reservedNames || [])
+  ];
+
+  return {
+    ...config,
+    reservedNames: unique(reservedNames)
+  };
+}
+
+function toExactNamePatterns(names) {
+  return names
+    .filter(name => typeof name === 'string' && name.length > 0)
+    .map(name => `^${escapeRegExp(name)}$`);
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function unique(values) {
+  return Array.from(new Set(values));
+}
+
+function toArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+module.exports.buildSafeConfig = buildSafeConfig;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,5 @@
 const readline = require('readline');
+const acorn = require('acorn');
 const {Command} = require('commander');
 const {Readable} = require('stream');
 const {
@@ -91,18 +92,266 @@ function shiftStartIndexOnNewLine(startIndex, code) {
   return startIndex;
 }
 
+function getMetroFactoryBodyRange(code) {
+  const factory = getMetroFactoryNode(code);
+  if (factory && factory.body && factory.body.type === 'BlockStatement') {
+    return {
+      start: factory.body.start,
+      end: factory.body.end - 1
+    };
+  }
+
+  return getMetroFactoryBodyRangeByScan(code);
+}
+
+function getMetroFactoryParamNames(code) {
+  const factory = getMetroFactoryNode(code);
+  if (factory && Array.isArray(factory.params)) {
+    return factory.params
+      .filter(param => param.type === 'Identifier')
+      .map(param => param.name);
+  }
+
+  return getMetroFactoryParamNamesByScan(code);
+}
+
+function getMetroFactoryNode(code) {
+  try {
+    const ast = acorn.parse(code, {
+      ecmaVersion: 'latest',
+      sourceType: 'script'
+    });
+    const statement = ast.body.find(node =>
+      node.type === 'ExpressionStatement' &&
+      node.expression.type === 'CallExpression' &&
+      node.expression.arguments[0] &&
+      (
+        node.expression.arguments[0].type === 'FunctionExpression' ||
+        node.expression.arguments[0].type === 'ArrowFunctionExpression'
+      )
+    );
+    const callExpression = statement && statement.expression;
+    const factory = callExpression &&
+      callExpression.type === 'CallExpression' &&
+      callExpression.arguments[0];
+
+    return factory || null;
+  } catch (error) {
+    if (process.env.DEBUG) {
+      console.warn('warning: Falling back to scanner for Metro module body:', error.message);
+    }
+  }
+
+  return null;
+}
+
+function getMetroFactoryBodyRangeByScan(code) {
+  const wrapperStart = code.indexOf('__d');
+  const functionStart = code.indexOf('function', wrapperStart === -1 ? 0 : wrapperStart);
+  const start = code.indexOf('{', functionStart === -1 ? 0 : functionStart);
+  if (start === -1) {
+    throw new Error('Unable to locate Metro module factory body for obfuscation.');
+  }
+
+  const end = findMatchingBrace(code, start);
+  return { start, end };
+}
+
+function getMetroFactoryParamNamesByScan(code) {
+  const wrapperStart = code.indexOf('__d');
+  const functionStart = code.indexOf('function', wrapperStart === -1 ? 0 : wrapperStart);
+  if (functionStart === -1) {
+    return [];
+  }
+
+  const paramsStart = code.indexOf('(', functionStart);
+  if (paramsStart === -1) {
+    return [];
+  }
+
+  const paramsEnd = findMatchingParen(code, paramsStart);
+  return code
+    .slice(paramsStart + 1, paramsEnd)
+    .split(',')
+    .map(param => param.trim())
+    .filter(param => /^[A-Za-z_$][0-9A-Za-z_$]*$/.test(param));
+}
+
+function findMatchingParen(code, start) {
+  let depth = 0;
+
+  for (let i = start; i < code.length; i++) {
+    const char = code[i];
+    const next = code[i + 1];
+
+    if (char === '\'' || char === '"') {
+      i = skipQuotedString(code, i, char);
+      continue;
+    }
+
+    if (char === '`') {
+      i = skipTemplateString(code, i);
+      continue;
+    }
+
+    if (char === '/' && next === '/') {
+      i = skipLineComment(code, i);
+      continue;
+    }
+
+    if (char === '/' && next === '*') {
+      i = skipBlockComment(code, i);
+      continue;
+    }
+
+    if (char === '(') {
+      depth++;
+      continue;
+    }
+
+    if (char === ')') {
+      depth--;
+      if (depth === 0) {
+        return i;
+      }
+    }
+  }
+
+  return code.length - 1;
+}
+
+function findMatchingBrace(code, start) {
+  let depth = 0;
+
+  for (let i = start; i < code.length; i++) {
+    const char = code[i];
+    const next = code[i + 1];
+
+    if (char === '\'' || char === '"') {
+      i = skipQuotedString(code, i, char);
+      continue;
+    }
+
+    if (char === '`') {
+      i = skipTemplateString(code, i);
+      continue;
+    }
+
+    if (char === '/' && next === '/') {
+      i = skipLineComment(code, i);
+      continue;
+    }
+
+    if (char === '/' && next === '*') {
+      i = skipBlockComment(code, i);
+      continue;
+    }
+
+    if (char === '/' && isRegexStart(code, i)) {
+      i = skipRegex(code, i);
+      continue;
+    }
+
+    if (char === '{') {
+      depth++;
+      continue;
+    }
+
+    if (char === '}') {
+      depth--;
+      if (depth === 0) {
+        return i;
+      }
+    }
+  }
+
+  throw new Error('Unable to locate Metro module factory body for obfuscation.');
+}
+
+function skipQuotedString(code, start, quote) {
+  for (let i = start + 1; i < code.length; i++) {
+    if (code[i] === '\\') {
+      i++;
+      continue;
+    }
+    if (code[i] === quote) {
+      return i;
+    }
+  }
+  return code.length - 1;
+}
+
+function skipTemplateString(code, start) {
+  for (let i = start + 1; i < code.length; i++) {
+    if (code[i] === '\\') {
+      i++;
+      continue;
+    }
+    if (code[i] === '`') {
+      return i;
+    }
+  }
+  return code.length - 1;
+}
+
+function skipLineComment(code, start) {
+  const end = code.indexOf('\n', start + 2);
+  return end === -1 ? code.length - 1 : end;
+}
+
+function skipBlockComment(code, start) {
+  const end = code.indexOf('*/', start + 2);
+  return end === -1 ? code.length - 1 : end + 1;
+}
+
+function skipRegex(code, start) {
+  let inCharacterClass = false;
+  for (let i = start + 1; i < code.length; i++) {
+    if (code[i] === '\\') {
+      i++;
+      continue;
+    }
+    if (code[i] === '[') {
+      inCharacterClass = true;
+      continue;
+    }
+    if (code[i] === ']') {
+      inCharacterClass = false;
+      continue;
+    }
+    if (code[i] === '/' && !inCharacterClass) {
+      return i;
+    }
+  }
+  return code.length - 1;
+}
+
+function isRegexStart(code, slashIndex) {
+  for (let i = slashIndex - 1; i >= 0; i--) {
+    const char = code[i];
+    if (/\s/.test(char)) {
+      continue;
+    }
+    return '({[=,:;!&|?+-*~^<>'.indexOf(char) !== -1;
+  }
+  return true;
+}
+
 /**
  * Wrap user code with  TAGS {BEG_ANNOTATION and END_ANNOTATION}
  * @param {{code: string}} data
  */
 function wrapCodeWithTags(data) {
-  let startIndex = data.code.indexOf('{');
-  const endIndex = data.code.lastIndexOf('}');
+  const reservedNames = getMetroFactoryParamNames(data.code);
+  const bodyRange = getMetroFactoryBodyRange(data.code);
+  let startIndex = bodyRange.start;
+  const endIndex = bodyRange.end;
   startIndex = shiftStartIndexOnNewLine(startIndex, data.code);
   const init = data.code.substring(0, startIndex + 1);
   const clientCode = data.code.substring(startIndex + 1, endIndex);
   const end = data.code.substr(endIndex, data.code.length);
   data.code = init + BEG_ANNOTATION + clientCode + END_ANNOTATION + end;
+  return { reservedNames };
 }
 
 /**
@@ -127,5 +376,9 @@ module.exports = {
   getBundlePath,
   stripTags,
   wrapCodeWithTags,
+  getMetroFactoryBodyRange,
+  getMetroFactoryBodyRangeByScan,
+  getMetroFactoryParamNames,
+  getMetroFactoryParamNamesByScan,
   buildNormalizePath
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.1.3",
       "license": "MIT",
       "dependencies": {
+        "acorn": "^8.16.0",
         "combine-source-map": "0.8.0",
         "commander": "2.20.3",
         "fs-extra": "8.1.0",
@@ -61,9 +62,9 @@
       "integrity": "sha512-YVtyAPqpefU+Mm/qqnOANW6IkqKpCSrarcyV269C8MA8Ux0dbkEuQwM/4CjL47kVEM2LgBef/ETfkH+c6+moFA=="
     },
     "node_modules/acorn": {
-      "version": "8.8.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
-      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -694,6 +695,17 @@
         "url": "https://opencollective.com/javascript-obfuscator"
       }
     },
+    "node_modules/javascript-obfuscator/node_modules/acorn": {
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/javascript-obfuscator/node_modules/commander": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.0.tgz",
@@ -1133,9 +1145,9 @@
       "integrity": "sha512-YVtyAPqpefU+Mm/qqnOANW6IkqKpCSrarcyV269C8MA8Ux0dbkEuQwM/4CjL47kVEM2LgBef/ETfkH+c6+moFA=="
     },
     "acorn": {
-      "version": "8.8.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
-      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw=="
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="
     },
     "ansi-styles": {
       "version": "4.3.0",
@@ -1597,6 +1609,11 @@
         "tslib": "2.5.0"
       },
       "dependencies": {
+        "acorn": {
+          "version": "8.8.2",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+          "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw=="
+        },
         "commander": {
           "version": "10.0.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lib": "lib"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test"
   },
   "repository": {
     "type": "git",
@@ -29,6 +29,7 @@
     "javascript-obfuscator"
   ],
   "dependencies": {
+    "acorn": "^8.16.0",
     "combine-source-map": "0.8.0",
     "commander": "2.20.3",
     "fs-extra": "8.1.0",

--- a/test/javascriptObfuscatorAPI.test.js
+++ b/test/javascriptObfuscatorAPI.test.js
@@ -1,0 +1,88 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const os = require('node:os');
+const path = require('node:path');
+const vm = require('node:vm');
+const { mkdirp, readFile, remove, writeFile } = require('fs-extra');
+const obfuscate = require('../lib/javascriptObfuscatorAPI');
+const { buildSafeConfig } = require('../lib/javascriptObfuscatorAPI');
+
+test('obfuscates optional chaining without changing runtime behavior', async () => {
+  const root = path.join(os.tmpdir(), `jso-metro-${Date.now()}-${process.pid}`);
+  const srcDir = path.join(root, 'src');
+  const distDir = path.join(root, 'dist');
+  const fileName = 'App.js';
+
+  await mkdirp(srcDir);
+  await writeFile(
+    path.join(srcDir, fileName),
+    'module.exports = function readValue(input) {\n' +
+      '  return input?.service?.getValue?.() ?? "fallback";\n' +
+      '};\n'
+  );
+
+  try {
+    await obfuscate({
+      config: {
+        compact: false,
+        controlFlowFlattening: true,
+        controlFlowFlatteningThreshold: 1,
+        stringArray: true
+      },
+      filesSrc: '**/*.js',
+      filesDest: distDir,
+      cwd: srcDir,
+      runConfig: {}
+    });
+
+    const code = await readFile(path.join(distDir, fileName), 'utf8');
+    const sandbox = { module: { exports: {} }, exports: {} };
+    vm.runInNewContext(code, sandbox);
+
+    assert.equal(sandbox.module.exports(undefined), 'fallback');
+    assert.equal(sandbox.module.exports({ service: {} }), 'fallback');
+    assert.equal(
+      sandbox.module.exports({ service: { getValue: () => 'value' } }),
+      'value'
+    );
+  } finally {
+    await remove(root);
+  }
+});
+
+test('reserves Metro wrapper parameters when using mangled identifiers', () => {
+  const config = buildSafeConfig(
+    {
+      compact: false,
+      identifierNamesGenerator: 'mangled',
+      stringArray: true
+    },
+    {
+      reservedNames: ['g', 'r', 'i', 'a', 'm', 'e', 'd']
+    }
+  );
+
+  const code = require('javascript-obfuscator')
+    .obfuscate(
+      'var React = i(r(d[0]));\n' +
+        'm.exports = React?.default?.createElement?.("View") ?? "fallback";\n',
+      config
+    )
+    .getObfuscatedCode();
+
+  const module = { exports: null };
+  const importDefault = value => ({ default: value });
+  const requireMock = id => ({
+    createElement: type => ({ type, id })
+  });
+
+  vm.runInNewContext(
+    `(function(g,r,i,a,m,e,d){${code}\n})(globalThis, requireMock, importDefault, null, module, {}, [0]);`,
+    { requireMock, importDefault, module }
+  );
+
+  assert.deepEqual(module.exports, { type: 'View', id: 0 });
+  assert.equal(/\b(function|var|let|const)\s+i\b/.test(code), false);
+  assert.equal(/\b(function|var|let|const)\s+r\b/.test(code), false);
+  assert.equal(/\b(function|var|let|const)\s+d\b/.test(code), false);
+});

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,0 +1,110 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const vm = require('node:vm');
+const JavaScriptObfuscator = require('javascript-obfuscator');
+const {
+  BEG_ANNOTATION,
+  END_ANNOTATION
+} = require('../lib/constants');
+const {
+  getMetroFactoryBodyRange,
+  getMetroFactoryBodyRangeByScan,
+  getMetroFactoryParamNames,
+  getMetroFactoryParamNamesByScan,
+  stripTags,
+  wrapCodeWithTags
+} = require('../lib/utils');
+
+function getTaggedBody(code) {
+  const start = code.indexOf(BEG_ANNOTATION) + BEG_ANNOTATION.length;
+  const end = code.indexOf(END_ANNOTATION);
+  return code.slice(start, end);
+}
+
+test('wrapCodeWithTags tags only the Metro factory body when metadata follows it', () => {
+  const data = {
+    code: '__d(function(global, require, importDefault, importAll, module, exports, dependencyMap) {\n' +
+      'var value = object?.method?.(dependencyMap[0]);\n' +
+      '}, 42, [7], { verboseName: "App", inverseDependencies: {} });'
+  };
+
+  wrapCodeWithTags(data);
+
+  assert.equal(getTaggedBody(data.code), 'var value = object?.method?.(dependencyMap[0]);\n');
+  assert.match(data.code, /\}, 42, \[7\], \{ verboseName: "App", inverseDependencies: \{\} \}\);$/);
+  assert.equal(stripTags(data.code).includes('object?.method?.(dependencyMap[0])'), true);
+});
+
+test('wrapCodeWithTags handles braces inside the module body without moving the end tag', () => {
+  const data = {
+    code: '__d(function(g, r, i, a, m, e, d) {\n' +
+      'const text = "}";\n' +
+      'const regex = /\\}/g;\n' +
+      'const value = ({ nested: true })?.nested;\n' +
+      '}, 1, [], { factory: true });'
+  };
+
+  wrapCodeWithTags(data);
+
+  assert.equal(
+    getTaggedBody(data.code),
+    'const text = "}";\nconst regex = /\\}/g;\nconst value = ({ nested: true })?.nested;\n'
+  );
+  assert.equal(stripTags(data.code).endsWith('}, 1, [], { factory: true });'), true);
+});
+
+test('getMetroFactoryBodyRange reports the block statement boundaries', () => {
+  const code = '"use strict";\nglobal.__d(function(g,r,i,a,m,e,d){\nlet x = maybe?.call?.();\n},123,[]);';
+  const range = getMetroFactoryBodyRange(code);
+
+  assert.equal(code[range.start], '{');
+  assert.equal(code[range.end], '}');
+  assert.equal(code.slice(range.start + 1, range.end), '\nlet x = maybe?.call?.();\n');
+  assert.deepEqual(getMetroFactoryParamNames(code), ['g', 'r', 'i', 'a', 'm', 'e', 'd']);
+});
+
+test('tagged Metro module can be obfuscated and keeps dependency metadata intact', () => {
+  const data = {
+    code: '__d(function(global, require, importDefault, importAll, module, exports, dependencyMap) {\n' +
+      'module.exports = dependencyMap?.[0]?.name ?? "fallback";\n' +
+      '}, 10, [{ name: "dep" }], { verboseName: "App", inverseDependencies: {} });'
+  };
+
+  wrapCodeWithTags(data);
+  const beforeTag = data.code.slice(0, data.code.indexOf(BEG_ANNOTATION));
+  const afterBegin = data.code.slice(data.code.indexOf(BEG_ANNOTATION) + BEG_ANNOTATION.length);
+  const userCode = afterBegin.slice(0, afterBegin.indexOf(END_ANNOTATION));
+  const afterTag = afterBegin.slice(afterBegin.indexOf(END_ANNOTATION) + END_ANNOTATION.length);
+  const obfuscatedCode = JavaScriptObfuscator
+    .obfuscate(userCode, { compact: false })
+    .getObfuscatedCode();
+  const finalBundle = beforeTag + obfuscatedCode + afterTag;
+  const captured = [];
+
+  vm.runInNewContext(finalBundle, {
+    __d: (...args) => captured.push(args)
+  });
+
+  assert.equal(captured.length, 1);
+  assert.equal(captured[0][1], 10);
+  assert.equal(JSON.stringify(captured[0][2]), JSON.stringify([{ name: 'dep' }]));
+  assert.equal(
+    JSON.stringify(captured[0][3]),
+    JSON.stringify({ verboseName: 'App', inverseDependencies: {} })
+  );
+
+  const module = { exports: undefined };
+  captured[0][0](global, null, null, null, module, {}, captured[0][2]);
+  assert.equal(module.exports, 'dep');
+});
+
+test('scanner fallback finds factory body without parsing the entire wrapper', () => {
+  const code = '__d(function(g,r,i,a,m,e,d){const a="{not end}";const b=/\\}/g;const c=`${"{still body}"}`;return d?.[0];},5,[1],{meta:{}});';
+  const range = getMetroFactoryBodyRangeByScan(code);
+
+  assert.equal(
+    code.slice(range.start + 1, range.end),
+    'const a="{not end}";const b=/\\}/g;const c=`${"{still body}"}`;return d?.[0];'
+  );
+  assert.deepEqual(getMetroFactoryParamNamesByScan(code), ['g', 'r', 'i', 'a', 'm', 'e', 'd']);
+});


### PR DESCRIPTION
Issue: Optional chaining (?.) causes runtime crashes in React Native New Architecture (RN 0.84.1) 

#32 


Root cause:

`obfuscator-io-metro-plugin` obfuscates only the body of Metro’s module wrapper:

```js
__d(function(g, r, i, a, m, e, d) {
  // user module code obfuscated here
}, moduleId, dependencyMap, metadata);
```
Metro wrapper parameters are runtime-critical helpers:

- r: require
- i: importDefault
- a: importAll
- m: module
- e: exports
- d: dependency map
When javascript-obfuscator is configured with identifierNamesGenerator: 'mangled' or 'mangled-shuffled', it may generate short helper names for its own string-array/decoder/runtime machinery. Those generated names can collide with Metro wrapper params because the obfuscator only sees the extracted body, not the outer function signature. For example, if the obfuscator emits `var i = ... or function a() { ... },` code that originally called Metro helpers can be redirected to obfuscator helpers:

```js
var React = i(r(d[0]));
```
After collision, `i `may no longer be Metro’s` importDefault`, causing runtime failures like:

`TypeError: undefined is not a function`
In RN 0.84.1/New Architecture, this is easier to trigger because modern Metro/Hermes output preserves newer syntax such as optional chaining and nullish coalescing, and the obfuscator may emit more helper machinery around those patterns.

Additional integration findings:

The RN 0.84.1 bundle also exposed two existing structural risks:

The old wrapper slicing used lastIndexOf('}'), which can accidentally include Metro metadata after the factory body.
The old file tracking used one source filename per module, but RN 0.84.1 can produce multiple output chunks per module, causing temp-file mapping desync.
Fix:

The plugin now:

- Locates the Metro factory body using AST parsing with a scanner fallback.
- Extracts actual wrapper parameter names per module wrapper.
- Reserves those names dynamically during obfuscation using exact reservedNames regexes.
- Tracks one temp file per wrapped output instead of assuming one output per module.
- Preserves user-provided reservedNames.
This avoids hardcoding Metro’s current parameter names and protects future wrapper shapes where Metro may emit different parameter identifiers.

Validation performed:

- npm test: 7/7 passed.
- Regression test for identifierNamesGenerator: 'mangled': passed.
- RN 0.84.1 iOS release bundle with New Architecture scaffold and mangled obfuscation: passed.
- Hermes bytecode compile of the obfuscated iOS bundle: passed.
- Integration app TypeScript check: passed.
- npm pack --dry-run: passed, with integration harness excluded from package output.
